### PR TITLE
Make sure the loggly backend app is started

### DIFF
--- a/lib/logger_loggly_backend.ex
+++ b/lib/logger_loggly_backend.ex
@@ -2,6 +2,7 @@ defmodule LoggerLogglyBackend do
   use GenEvent
 
   def init({__MODULE__, name}) do
+    {:ok, _} = Application.ensure_all_started(:logger_loggly_backend)
     {:ok, configure(name, [])}
   end
 


### PR DESCRIPTION
Since the backend is added via configuration, we need to make
sure all dependencies are started when the backend is added.